### PR TITLE
Add Vitest and service unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.11.3",
@@ -37,6 +38,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.1.4"
+    "vite": "^5.1.4",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/services/Services/index.test.ts
+++ b/src/services/Services/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { getServiceById } from './index';
+import { services } from '../mocks/services';
+
+describe('getServiceById', () => {
+  it('returns the correct service when provided a known id', () => {
+    const id = 'ai-public-bidding';
+    const expected = services.find(service => service.id === id);
+    expect(getServiceById(id)).toEqual(expected);
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(getServiceById('unknown-id')).toBeUndefined();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest test configuration
- add a test script and vitest dev dependency
- cover `getServiceById` with unit tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f6f72e888333a4f651e1f39c141a