### PR TITLE
Atualiza textos sobre 'Serviços' para 'Ferramentas'

### DIFF
--- a/src/libs/components/Footer.tsx
+++ b/src/libs/components/Footer.tsx
@@ -63,7 +63,7 @@ const Footer: React.FC = () => {
               display="block"
               sx={{ mb: 1 }}
             >
-              Services
+              Ferramentas
             </Link>
             <Link href="#faq" color="inherit" display="block" sx={{ mb: 1 }}>
               FAQ

--- a/src/screens/Home/ContactSection.tsx
+++ b/src/screens/Home/ContactSection.tsx
@@ -71,8 +71,8 @@ const ContactSection: React.FC = () => {
               </Typography>
 
               <Typography paragraph color="text.secondary" sx={{ mb: 4 }}>
-                Estamos animados para ouvir você! Seja uma pergunta sobre nossos
-                serviços, preços ou qualquer outra coisa, nossa equipe está
+                Estamos animados para ouvir você! Seja uma pergunta sobre nossas
+                ferramentas, preços ou qualquer outra coisa, nossa equipe está
                 pronta para responder a todas as suas dúvidas.
               </Typography>
 

--- a/src/screens/Home/HeroSection.tsx
+++ b/src/screens/Home/HeroSection.tsx
@@ -105,7 +105,7 @@ const HeroSection: React.FC = () => {
                       borderRadius: "50px",
                     }}
                   >
-                    Nossos Serviços
+                    Nossas Ferramentas
                   </Button>
                 </ScrollLink>
               </Box>

--- a/src/screens/Home/ServicesSection.tsx
+++ b/src/screens/Home/ServicesSection.tsx
@@ -37,7 +37,7 @@ const ServicesSection: React.FC = () => {
               },
             }}
           >
-            Nossos Serviços
+            Nossas Ferramentas
           </Typography>
 
           <Typography

--- a/src/screens/Service/index.tsx
+++ b/src/screens/Service/index.tsx
@@ -22,10 +22,10 @@ const ServicePage: React.FC = () => {
     return (
       <Container maxWidth="md" sx={{ py: 10, textAlign: "center" }}>
         <Typography variant="h4" gutterBottom>
-          Serviço não encontrado
+          Ferramenta não encontrada
         </Typography>
         <Typography paragraph>
-          O serviço que você está procurando não existe ou foi removido.
+          A ferramenta que você está procurando não existe ou foi removida.
         </Typography>
         <Button
           variant="contained"
@@ -137,7 +137,7 @@ const ServicePage: React.FC = () => {
                   variant="outlined"
                   color="secondary"
                   size="large"
-                  href="https://wa.me/SEUNUMERO?text=Olá, quero testar o serviço da NeoLeadsAI!"
+                  href="https://wa.me/SEUNUMERO?text=Olá, quero testar a ferramenta da NeoLeadsAI!"
                   target="_blank"
                 >
                   💬 Falar com um especialista


### PR DESCRIPTION
## Summary
- atualiza título de serviços para ferramentas
- renomeia botão de serviços na home
- ajusta textos do contato e do serviço
- renomeia link no rodapé para ferramentas

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f99b41f88333a802bb9351fe2e76