### PR TITLE
Unify theme palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=Source+Sans+Pro:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
     <title>Conectiva</title>

--- a/src/libs/components/ServiceCard.tsx
+++ b/src/libs/components/ServiceCard.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
 } from "@mui/material";
+import { useTheme, alpha } from "@mui/material/styles";
 import { useNavigate } from "react-router-dom";
 import { GanttChart, Mail, Search } from "lucide-react";
 import { Service } from "../interfaces/Service";
@@ -17,6 +18,7 @@ interface ServiceCardProps {
 
 const ServiceCard: React.FC<ServiceCardProps> = ({ service }) => {
   const navigate = useNavigate();
+  const theme = useTheme();
 
   const handleServiceClick = () => {
     navigate(`/service/${service.id}`);
@@ -26,13 +28,13 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ service }) => {
   const getIcon = () => {
     switch (service.icon) {
       case "GanttChart":
-        return <GanttChart size={40} color="#1976D2" />;
+        return <GanttChart size={40} color={theme.palette.primary.main} />;
       case "Mail":
-        return <Mail size={40} color="#1976D2" />;
+        return <Mail size={40} color={theme.palette.primary.main} />;
       case "Search":
-        return <Search size={40} color="#1976D2" />;
+        return <Search size={40} color={theme.palette.primary.main} />;
       default:
-        return <GanttChart size={40} color="#1976D2" />;
+        return <GanttChart size={40} color={theme.palette.primary.main} />;
     }
   };
 
@@ -56,7 +58,7 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ service }) => {
           justifyContent: "center",
           alignItems: "center",
           p: 3,
-          backgroundColor: "rgba(25, 118, 210, 0.05)",
+          backgroundColor: alpha(theme.palette.primary.main, 0.05),
         }}
       >
         {getIcon()}

--- a/src/libs/theme/theme.ts
+++ b/src/libs/theme/theme.ts
@@ -4,15 +4,15 @@ import { createTheme } from '@mui/material/styles';
 const theme = createTheme({
   palette: {
     primary: {
-      light: '#4dabf5',
-      main: '#1976D2',
-      dark: '#0D47A1',
+      light: '#8e63f9',
+      main: '#6a11cb',
+      dark: '#4b088a',
       contrastText: '#fff',
     },
     secondary: {
-      light: '#33ab9f',
-      main: '#00796B',
-      dark: '#004D40',
+      light: '#4895ff',
+      main: '#2575fc',
+      dark: '#1a54b3',
       contrastText: '#fff',
     },
     success: {
@@ -29,7 +29,7 @@ const theme = createTheme({
     },
   },
   typography: {
-    fontFamily: '"Source Sans Pro", "Roboto", "Helvetica", "Arial", sans-serif',
+    fontFamily: '"Inter", "Source Sans Pro", "Roboto", "Helvetica", "Arial", sans-serif',
     h1: {
       fontWeight: 600,
       fontSize: '2.75rem',

--- a/src/screens/Home/ContactSection.tsx
+++ b/src/screens/Home/ContactSection.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { Box, Typography, Container, Grid } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import ContactForm from "../../libs/components/ContactForm";
 import { Phone, Mail, MapPin } from "lucide-react";
 
 const ContactSection: React.FC = () => {
+  const theme = useTheme();
   return (
     <Box
       id="contact"
@@ -79,7 +81,7 @@ const ContactSection: React.FC = () => {
               <Box sx={{ mb: 3, display: "flex", alignItems: "center" }}>
                 <MapPin
                   size={24}
-                  color="#1976D2"
+                  color={theme.palette.primary.main}
                   style={{ marginRight: "12px" }}
                 />
                 <Typography>Natal, RN</Typography>
@@ -88,7 +90,7 @@ const ContactSection: React.FC = () => {
               <Box sx={{ mb: 3, display: "flex", alignItems: "center" }}>
                 <Mail
                   size={24}
-                  color="#1976D2"
+                  color={theme.palette.primary.main}
                   style={{ marginRight: "12px" }}
                 />
                 <Typography>info@conectiva.com</Typography>
@@ -97,7 +99,7 @@ const ContactSection: React.FC = () => {
               <Box sx={{ mb: 4, display: "flex", alignItems: "center" }}>
                 <Phone
                   size={24}
-                  color="#1976D2"
+                  color={theme.palette.primary.main}
                   style={{ marginRight: "12px" }}
                 />
                 <Typography>(84) 99975-0179</Typography>

--- a/src/screens/Home/HeroSection.tsx
+++ b/src/screens/Home/HeroSection.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box, Typography, Button, Container, Grid } from "@mui/material";
+import { useTheme, alpha } from "@mui/material/styles";
 import { Link as ScrollLink } from "react-scroll";
 import { ArrowRight, Cpu } from "lucide-react";
 import { motion } from "framer-motion";
@@ -7,6 +8,7 @@ import { motion } from "framer-motion";
 const MotionButton = motion(Button);
 
 const HeroSection: React.FC = () => {
+  const theme = useTheme();
   return (
     <Box
       id="home"
@@ -85,7 +87,7 @@ const HeroSection: React.FC = () => {
                       px: 3,
                       fontWeight: 600,
                       borderRadius: "50px",
-                      boxShadow: "0 8px 20px rgba(25, 118, 210, 0.4)",
+                      boxShadow: `0 8px 20px ${alpha(theme.palette.primary.main, 0.4)}`,
                     }}
                   >
                     Comece Gratuitamente


### PR DESCRIPTION
## Summary
- update global theme colors and typography
- adjust ServiceCard and ContactSection to use theme palette
- tweak hero button shadow to reference theme
- include Inter font in HTML

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68433f912e708333bc4adee823fd4044