### PR TITLE
Improve navigation spacing and smooth scroll

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,13 @@ import { ThemeProvider, CssBaseline, Box } from '@mui/material';
 import theme from './libs/theme/theme';
 import Navbar from './libs/components/Navbar';
 import Footer from './libs/components/Footer';
+import ScrollToTop from './libs/components/ScrollToTop';
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
+      <ScrollToTop />
       <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
         <Navbar />
         <Box sx={{ flexGrow: 1 }}>

--- a/src/libs/components/BackHomeButton.tsx
+++ b/src/libs/components/BackHomeButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Button } from '@mui/material';
+import { ArrowLeft } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+interface BackHomeButtonProps {
+  sx?: SxProps<Theme>;
+}
+
+const BackHomeButton: React.FC<BackHomeButtonProps> = ({ sx }) => {
+  const navigate = useNavigate();
+  return (
+    <Button
+      startIcon={<ArrowLeft />}
+      onClick={() => navigate('/')}
+      variant="outlined"
+      size="medium"
+      sx={{ mb: 4, ...sx }}
+      aria-label="Voltar para a página principal"
+    >
+      Voltar para a página principal
+    </Button>
+  );
+};
+
+export default BackHomeButton;

--- a/src/libs/components/ScrollToTop.tsx
+++ b/src/libs/components/ScrollToTop.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop: React.FC = () => {
+  const { pathname, hash } = useLocation();
+
+  useEffect(() => {
+    if (hash) {
+      const element = document.querySelector(hash);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+        return;
+      }
+    }
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [pathname, hash]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/screens/About/index.tsx
+++ b/src/screens/About/index.tsx
@@ -1,25 +1,13 @@
 import React from "react";
-import { Box, Button, Container } from "@mui/material";
-import { useNavigate } from "react-router-dom";
-import { Home } from "lucide-react";
+import { Box } from "@mui/material";
 import AboutSection from "../Home/AboutSection";
+import BackHomeButton from "../../libs/components/BackHomeButton";
 
 const AboutPage: React.FC = () => {
-  const navigate = useNavigate();
 
   return (
-    <Box sx={{ pt: { xs: 8, md: 10 } }}>
-      <Container maxWidth="lg" sx={{ py: 2 }}>
-        <Button
-          startIcon={<Home />}
-          onClick={() => navigate("/")}
-          variant="outlined"
-          sx={{ mb: 4 }}
-        >
-          Voltar para Home
-        </Button>
-      </Container>
-      <AboutSection />
+    <Box sx={{ pt: { xs: 6, md: 8 } }}>
+      <AboutSection topAction={<BackHomeButton />} />
     </Box>
   );
 };

--- a/src/screens/Contact/index.tsx
+++ b/src/screens/Contact/index.tsx
@@ -1,25 +1,12 @@
 import React from "react";
-import { Box, Button, Container } from "@mui/material";
-import { useNavigate } from "react-router-dom";
-import { Home } from "lucide-react";
+import { Box } from "@mui/material";
 import ContactSection from "../Home/ContactSection";
+import BackHomeButton from "../../libs/components/BackHomeButton";
 
 const ContactPage: React.FC = () => {
-  const navigate = useNavigate();
-
   return (
-    <Box sx={{ pt: { xs: 8, md: 10 } }}>
-      <Container maxWidth="lg" sx={{ py: 2 }}>
-        <Button
-          startIcon={<Home />}
-          onClick={() => navigate("/")}
-          variant="outlined"
-          sx={{ mb: 4 }}
-        >
-          Voltar para Home
-        </Button>
-      </Container>
-      <ContactSection />
+    <Box sx={{ pt: { xs: 6, md: 8 } }}>
+      <ContactSection topAction={<BackHomeButton />} />
     </Box>
   );
 };

--- a/src/screens/Home/AboutSection.tsx
+++ b/src/screens/Home/AboutSection.tsx
@@ -16,7 +16,11 @@ interface StatItem {
   label: string;
 }
 
-const AboutSection: React.FC = () => {
+interface AboutSectionProps {
+  topAction?: React.ReactNode;
+}
+
+const AboutSection: React.FC<AboutSectionProps> = ({ topAction }) => {
   const theme = useTheme();
 
   const stats: StatItem[] = [
@@ -51,6 +55,7 @@ const AboutSection: React.FC = () => {
       }}
     >
       <Container maxWidth="lg">
+        {topAction && <Box sx={{ mb: 4 }}>{topAction}</Box>}
         <Box sx={{ textAlign: "center", mb: 8 }}>
           <Typography
             variant="h2"

--- a/src/screens/Home/ContactSection.tsx
+++ b/src/screens/Home/ContactSection.tsx
@@ -4,7 +4,11 @@ import { useTheme } from "@mui/material/styles";
 import ContactForm from "../../libs/components/ContactForm";
 import { Phone, Mail, MapPin } from "lucide-react";
 
-const ContactSection: React.FC = () => {
+interface ContactSectionProps {
+  topAction?: React.ReactNode;
+}
+
+const ContactSection: React.FC<ContactSectionProps> = ({ topAction }) => {
   const theme = useTheme();
   return (
     <Box
@@ -15,6 +19,7 @@ const ContactSection: React.FC = () => {
       }}
     >
       <Container maxWidth="lg">
+        {topAction && <Box sx={{ mb: 4 }}>{topAction}</Box>}
         <Box sx={{ textAlign: "center", mb: 8 }}>
           <Typography
             variant="h2"

--- a/src/screens/Home/PricingSection.tsx
+++ b/src/screens/Home/PricingSection.tsx
@@ -59,7 +59,11 @@ const pricingPlans = [
   },
 ];
 
-const PricingSection: React.FC = () => {
+interface PricingSectionProps {
+  topAction?: React.ReactNode;
+}
+
+const PricingSection: React.FC<PricingSectionProps> = ({ topAction }) => {
   const navigate = useNavigate();
 
   return (
@@ -70,6 +74,7 @@ const PricingSection: React.FC = () => {
       }}
     >
       <Container maxWidth="lg">
+        {topAction && <Box sx={{ mb: 4 }}>{topAction}</Box>}
         <Box sx={{ textAlign: "center", mb: 8 }}>
           <Typography
             variant="h2"

--- a/src/screens/Plans/index.tsx
+++ b/src/screens/Plans/index.tsx
@@ -1,25 +1,12 @@
 import React from "react";
-import { Box, Button, Container } from "@mui/material";
-import { useNavigate } from "react-router-dom";
-import { Home } from "lucide-react";
+import { Box } from "@mui/material";
 import PricingSection from "../Home/PricingSection";
+import BackHomeButton from "../../libs/components/BackHomeButton";
 
 const PlansPage: React.FC = () => {
-  const navigate = useNavigate();
-
   return (
-    <Box sx={{ pt: { xs: 8, md: 10 } }}>
-      <Container maxWidth="lg" sx={{ py: 2 }}>
-        <Button
-          startIcon={<Home />}
-          onClick={() => navigate("/")}
-          variant="outlined"
-          sx={{ mb: 4 }}
-        >
-          Voltar para Home
-        </Button>
-      </Container>
-      <PricingSection />
+    <Box sx={{ pt: { xs: 6, md: 8 } }}>
+      <PricingSection topAction={<BackHomeButton />} />
     </Box>
   );
 };

--- a/src/screens/Service/index.tsx
+++ b/src/screens/Service/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import {
   Box,
   Container,
@@ -9,12 +9,11 @@ import {
   Divider,
   Grid,
 } from "@mui/material";
-import { ArrowLeft } from "lucide-react";
+import BackHomeButton from "../../libs/components/BackHomeButton";
 import { getServiceById } from "../../services/Services";
 
 const ServicePage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
 
   const service = getServiceById(id ?? "");
 
@@ -27,14 +26,7 @@ const ServicePage: React.FC = () => {
         <Typography paragraph>
           A ferramenta que você está procurando não existe ou foi removida.
         </Typography>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={() => navigate("/")}
-          sx={{ mt: 2 }}
-        >
-          Voltar para a página inicial
-        </Button>
+        <BackHomeButton sx={{ mt: 2 }} />
       </Container>
     );
   }
@@ -84,15 +76,9 @@ const ServicePage: React.FC = () => {
   };
 
   return (
-    <Box sx={{ pt: { xs: 12, md: 16 }, pb: { xs: 8, md: 12 } }}>
+    <Box sx={{ pt: { xs: 10, md: 12 }, pb: { xs: 8, md: 12 } }}>
       <Container maxWidth="lg">
-        <Button
-          startIcon={<ArrowLeft />}
-          sx={{ mb: 4 }}
-          onClick={() => navigate("/")}
-        >
-          Voltar para a página inicial
-        </Button>
+        <BackHomeButton />
 
         <Paper
           elevation={2}
@@ -201,3 +187,4 @@ const ServicePage: React.FC = () => {
 };
 
 export default ServicePage;
+


### PR DESCRIPTION
## Summary
- add BackHomeButton component for consistent navigation back to the homepage
- implement ScrollToTop to reset scroll position on route change
- use BackHomeButton across pages via section `topAction` prop
- decrease top padding on content pages to remove large gaps below the navbar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843446aa1e0833391ed68e6d1198d97