### PR TITLE
Fix navbar padding on internal pages

### DIFF
--- a/src/screens/About/index.tsx
+++ b/src/screens/About/index.tsx
@@ -6,7 +6,7 @@ import BackHomeButton from "../../libs/components/BackHomeButton";
 const AboutPage: React.FC = () => {
 
   return (
-    <Box sx={{ pt: { xs: 6, md: 8 } }}>
+    <Box>
       <AboutSection topAction={<BackHomeButton />} />
     </Box>
   );

--- a/src/screens/Contact/index.tsx
+++ b/src/screens/Contact/index.tsx
@@ -5,7 +5,7 @@ import BackHomeButton from "../../libs/components/BackHomeButton";
 
 const ContactPage: React.FC = () => {
   return (
-    <Box sx={{ pt: { xs: 6, md: 8 } }}>
+    <Box>
       <ContactSection topAction={<BackHomeButton />} />
     </Box>
   );

--- a/src/screens/Plans/index.tsx
+++ b/src/screens/Plans/index.tsx
@@ -5,7 +5,7 @@ import BackHomeButton from "../../libs/components/BackHomeButton";
 
 const PlansPage: React.FC = () => {
   return (
-    <Box sx={{ pt: { xs: 6, md: 8 } }}>
+    <Box>
       <PricingSection topAction={<BackHomeButton />} />
     </Box>
   );

--- a/src/screens/Service/index.tsx
+++ b/src/screens/Service/index.tsx
@@ -76,7 +76,7 @@ const ServicePage: React.FC = () => {
   };
 
   return (
-    <Box sx={{ pt: { xs: 10, md: 12 }, pb: { xs: 8, md: 12 } }}>
+    <Box sx={{ pb: { xs: 8, md: 12 } }}>
       <Container maxWidth="lg">
         <BackHomeButton />
 


### PR DESCRIPTION
## Summary
- remove top padding from About page
- remove top padding from Contact page
- remove top padding from Plans page
- remove top padding from Service page

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68434c6b700483339c93f175571005d3