### PR TITLE
Add Axios config for backend APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.1",
-    "react-scroll": "^1.8.9"
+    "react-scroll": "^1.8.9",
+    "axios": "^1.6.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/services/apiIA.ts
+++ b/src/services/apiIA.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const apiIA = axios.create({
+  baseURL: 'http://localhost:3333',
+  timeout: 20000,
+});

--- a/src/services/apiNode.ts
+++ b/src/services/apiNode.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const apiNode = axios.create({
+  baseURL: 'http://localhost:3331',
+  timeout: 10000,
+});


### PR DESCRIPTION
## Summary
- add axios config for Node backend
- add axios config for Flask backend
- include axios as dependency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68434f1c0cb083338406f42fb8a420e0