### PR TITLE
Implement login screen with Firebase auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.1",
     "react-scroll": "^1.8.9",
-    "axios": "^1.6.5"
+    "axios": "^1.6.5",
+    "firebase": "^10.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/libs/context/AuthContext.tsx
+++ b/src/libs/context/AuthContext.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import type { User } from "firebase/auth";
+import {
+  GoogleAuthProvider,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+  signOut,
+  onAuthStateChanged,
+} from "firebase/auth";
+import { auth } from "../../services/firebase";
+
+interface AuthContextProps {
+  user: User | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  loginWithGoogle: () => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextProps>({
+  user: null,
+  loading: true,
+  login: async () => {},
+  loginWithGoogle: async () => {},
+  logout: async () => {},
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser);
+      setLoading(false);
+      if (currentUser) {
+        localStorage.setItem("authUser", JSON.stringify(currentUser));
+      } else {
+        localStorage.removeItem("authUser");
+      }
+    });
+    return unsubscribe;
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    await signInWithEmailAndPassword(auth, email, password);
+  };
+
+  const loginWithGoogle = async () => {
+    const provider = new GoogleAuthProvider();
+    await signInWithPopup(auth, provider);
+  };
+
+  const logout = async () => {
+    await signOut(auth);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, loginWithGoogle, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
+import { AuthProvider } from './libs/context/AuthContext';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,6 +6,9 @@ import ServicePage from './screens/Service';
 import AboutPage from './screens/About';
 import PlansPage from './screens/Plans';
 import ContactPage from './screens/Contact';
+import LoginPage from './screens/Login';
+import RegisterPage from './screens/Register';
+import DashboardPage from './screens/Dashboard';
 
 const router = createBrowserRouter([
   {
@@ -31,6 +34,18 @@ const router = createBrowserRouter([
       {
         path: 'contato',
         element: <ContactPage />,
+      },
+      {
+        path: 'login',
+        element: <LoginPage />,
+      },
+      {
+        path: 'cadastro',
+        element: <RegisterPage />,
+      },
+      {
+        path: 'dashboard',
+        element: <DashboardPage />,
       },
     ],
   },

--- a/src/screens/Dashboard/index.tsx
+++ b/src/screens/Dashboard/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+
+const DashboardPage: React.FC = () => {
+  return (
+    <Box sx={{ mt: 6, textAlign: "center" }}>
+      <Typography variant="h4" gutterBottom>
+        Bem-vindo ao Painel do Usuário
+      </Typography>
+    </Box>
+  );
+};
+
+export default DashboardPage;

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Paper,
+  TextField,
+  Button,
+  Typography,
+  Alert,
+  Link,
+} from "@mui/material";
+import { useNavigate, Link as RouterLink } from "react-router-dom";
+import { useAuth } from "../../libs/context/AuthContext";
+
+interface FormErrors {
+  email?: string;
+  password?: string;
+  general?: string;
+}
+
+const LoginPage: React.FC = () => {
+  const { login, loginWithGoogle } = useAuth();
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [loading, setLoading] = useState(false);
+
+  const validate = (): boolean => {
+    const newErrors: FormErrors = {};
+    let valid = true;
+
+    if (!email.trim()) {
+      newErrors.email = "E-mail é obrigatório";
+      valid = false;
+    } else if (!/\S+@\S+\.\S+/.test(email)) {
+      newErrors.email = "E-mail inválido";
+      valid = false;
+    }
+
+    if (!password.trim()) {
+      newErrors.password = "Senha é obrigatória";
+      valid = false;
+    }
+
+    setErrors(newErrors);
+    return valid;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+    setLoading(true);
+    try {
+      await login(email, password);
+      navigate("/dashboard");
+    } catch (err: any) {
+      setErrors({ general: "Falha ao fazer login" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleGoogle = async () => {
+    setLoading(true);
+    try {
+      await loginWithGoogle();
+      navigate("/dashboard");
+    } catch (err) {
+      setErrors({ general: "Falha ao fazer login" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ display: "flex", justifyContent: "center", mt: 6 }}>
+      <Paper elevation={2} sx={{ p: 4, maxWidth: 400, width: "100%" }}>
+        <Typography variant="h4" gutterBottom>
+          Entrar
+        </Typography>
+        {errors.general && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {errors.general}
+          </Alert>
+        )}
+        <Box component="form" onSubmit={handleSubmit} noValidate>
+          <TextField
+            fullWidth
+            label="E-mail"
+            type="email"
+            margin="normal"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            error={!!errors.email}
+            helperText={errors.email}
+          />
+          <TextField
+            fullWidth
+            label="Senha"
+            type="password"
+            margin="normal"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            error={!!errors.password}
+            helperText={errors.password}
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={loading}
+            sx={{ mt: 2 }}
+          >
+            {loading ? "Carregando..." : "Entrar"}
+          </Button>
+        </Box>
+        <Button
+          variant="outlined"
+          fullWidth
+          onClick={handleGoogle}
+          disabled={loading}
+          sx={{ mt: 2 }}
+        >
+          Entrar com Google
+        </Button>
+        <Typography variant="body2" align="center" sx={{ mt: 2 }}>
+          Ainda não tem conta?{' '}
+          <Link component={RouterLink} to="/cadastro">
+            Cadastre-se
+          </Link>
+        </Typography>
+      </Paper>
+    </Box>
+  );
+};
+
+export default LoginPage;

--- a/src/screens/Register/index.tsx
+++ b/src/screens/Register/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+
+const RegisterPage: React.FC = () => {
+  return (
+    <Box sx={{ mt: 6, textAlign: "center" }}>
+      <Typography variant="h4" gutterBottom>
+        Página de Cadastro
+      </Typography>
+      <Typography>
+        Formulário de cadastro pendente de implementação.
+      </Typography>
+    </Box>
+  );
+};
+
+export default RegisterPage;

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,0 +1,15 @@
+import { initializeApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+
+export const auth = getAuth(app);


### PR DESCRIPTION
## Summary
- set up Firebase service and authentication context
- add login page with e-mail/senha validation and Google sign-in
- create placeholder pages for cadastro and dashboard
- register new routes and wrap app with AuthProvider
- add Firebase dependency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684350378d7c83339325ed5546809224