### PR TITLE
Add user registration screen

### DIFF
--- a/src/libs/context/AuthContext.tsx
+++ b/src/libs/context/AuthContext.tsx
@@ -6,6 +6,8 @@ import {
   signInWithPopup,
   signOut,
   onAuthStateChanged,
+  createUserWithEmailAndPassword,
+  updateProfile,
 } from "firebase/auth";
 import { auth } from "../../services/firebase";
 
@@ -13,6 +15,7 @@ interface AuthContextProps {
   user: User | null;
   loading: boolean;
   login: (email: string, password: string) => Promise<void>;
+  signUp: (name: string, email: string, password: string) => Promise<void>;
   loginWithGoogle: () => Promise<void>;
   logout: () => Promise<void>;
 }
@@ -21,6 +24,7 @@ const AuthContext = createContext<AuthContextProps>({
   user: null,
   loading: true,
   login: async () => {},
+  signUp: async () => {},
   loginWithGoogle: async () => {},
   logout: async () => {},
 });
@@ -48,6 +52,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     await signInWithEmailAndPassword(auth, email, password);
   };
 
+  const signUp = async (name: string, email: string, password: string) => {
+    const cred = await createUserWithEmailAndPassword(auth, email, password);
+    if (cred.user && name) {
+      await updateProfile(cred.user, { displayName: name });
+    }
+  };
+
   const loginWithGoogle = async () => {
     const provider = new GoogleAuthProvider();
     await signInWithPopup(auth, provider);
@@ -58,7 +69,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, loginWithGoogle, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, signUp, loginWithGoogle, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/screens/Register/index.tsx
+++ b/src/screens/Register/index.tsx
@@ -1,15 +1,155 @@
-import React from "react";
-import { Box, Typography } from "@mui/material";
+import React, { useState } from "react";
+import {
+  Box,
+  Paper,
+  TextField,
+  Button,
+  Typography,
+  Alert,
+  Link,
+} from "@mui/material";
+import { useNavigate, Link as RouterLink } from "react-router-dom";
+import { useAuth } from "../../libs/context/AuthContext";
+
+interface FormErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  general?: string;
+}
 
 const RegisterPage: React.FC = () => {
+  const { signUp } = useAuth();
+  const navigate = useNavigate();
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [loading, setLoading] = useState(false);
+
+  const validate = (): boolean => {
+    const newErrors: FormErrors = {};
+    let valid = true;
+
+    if (!name.trim()) {
+      newErrors.name = "Nome é obrigatório";
+      valid = false;
+    }
+
+    if (!email.trim()) {
+      newErrors.email = "E-mail é obrigatório";
+      valid = false;
+    } else if (!/\S+@\S+\.\S+/.test(email)) {
+      newErrors.email = "E-mail inválido";
+      valid = false;
+    }
+
+    if (!password) {
+      newErrors.password = "Senha é obrigatória";
+      valid = false;
+    } else if (password.length < 6) {
+      newErrors.password = "Senha deve ter pelo menos 6 caracteres";
+      valid = false;
+    }
+
+    if (!confirmPassword) {
+      newErrors.confirmPassword = "Confirme a senha";
+      valid = false;
+    } else if (confirmPassword !== password) {
+      newErrors.confirmPassword = "Senhas não conferem";
+      valid = false;
+    }
+
+    setErrors(newErrors);
+    return valid;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+    setLoading(true);
+    try {
+      await signUp(name, email, password);
+      navigate("/dashboard");
+    } catch (err) {
+      setErrors({ general: "Falha ao criar conta" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <Box sx={{ mt: 6, textAlign: "center" }}>
-      <Typography variant="h4" gutterBottom>
-        Página de Cadastro
-      </Typography>
-      <Typography>
-        Formulário de cadastro pendente de implementação.
-      </Typography>
+    <Box sx={{ display: "flex", justifyContent: "center", mt: 6 }}>
+      <Paper elevation={2} sx={{ p: 4, maxWidth: 400, width: "100%" }}>
+        <Typography variant="h4" gutterBottom>
+          Criar Conta
+        </Typography>
+        {errors.general && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {errors.general}
+          </Alert>
+        )}
+        <Box component="form" onSubmit={handleSubmit} noValidate>
+          <TextField
+            fullWidth
+            label="Nome completo"
+            margin="normal"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            error={!!errors.name}
+            helperText={errors.name}
+          />
+          <TextField
+            fullWidth
+            label="E-mail"
+            type="email"
+            margin="normal"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            error={!!errors.email}
+            helperText={errors.email}
+          />
+          <TextField
+            fullWidth
+            label="Senha"
+            type="password"
+            margin="normal"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            error={!!errors.password}
+            helperText={errors.password}
+          />
+          <TextField
+            fullWidth
+            label="Confirmar senha"
+            type="password"
+            margin="normal"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            error={!!errors.confirmPassword}
+            helperText={errors.confirmPassword}
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            fullWidth
+            disabled={loading}
+            sx={{ mt: 2 }}
+          >
+            {loading ? "Carregando..." : "Criar Conta"}
+          </Button>
+        </Box>
+        <Typography variant="body2" align="center" sx={{ mt: 2 }}>
+          Já tem uma conta?{' '}
+          <Link component={RouterLink} to="/login">
+            Faça login
+          </Link>
+        </Typography>
+      </Paper>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- enable account creation via Firebase
- build registration screen with validation and feedback

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68435b5e1e6483338db31f8b10c7c9d6