### PR TITLE
Add placeholder pages for agent routes

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,6 +8,8 @@ import PlansPage from './screens/Plans';
 import ContactPage from './screens/Contact';
 import LoginPage from './screens/Login';
 import RegisterPage from './screens/Register';
+import EditalPage from './screens/Agent/Edital';
+import ProspeccaoPage from './screens/Agent/Prospeccao';
 import DashboardLayout from './screens/Dashboard';
 import DashboardHome from './screens/Dashboard/Home';
 import AgentPage from './screens/Dashboard/Agent';
@@ -48,6 +50,14 @@ const router = createBrowserRouter([
       {
         path: 'cadastro',
         element: <RegisterPage />,
+      },
+      {
+        path: 'agent/edital',
+        element: <EditalPage />,
+      },
+      {
+        path: 'agent/prospeccao',
+        element: <ProspeccaoPage />,
       },
       {
         path: 'dashboard',

--- a/src/screens/Agent/Edital.tsx
+++ b/src/screens/Agent/Edital.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Box, Typography, Button } from "@mui/material";
+import ConstructionIcon from "@mui/icons-material/Construction";
+import { useNavigate } from "react-router-dom";
+
+const EditalPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      height="80vh"
+      textAlign="center"
+    >
+      <ConstructionIcon sx={{ fontSize: 80, mb: 2, color: "primary.main" }} />
+      <Typography variant="h3" gutterBottom>
+        Funcionalidade em Desenvolvimento 🚧
+      </Typography>
+      <Typography variant="body1" mb={4}>
+        Estamos trabalhando nesta funcionalidade. Em breve, ela estará disponível para você!
+      </Typography>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={() => navigate("/dashboard")}
+      >
+        Voltar para o Painel
+      </Button>
+    </Box>
+  );
+};
+
+export default EditalPage;

--- a/src/screens/Agent/Prospeccao.tsx
+++ b/src/screens/Agent/Prospeccao.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Box, Typography, Button } from "@mui/material";
+import ConstructionIcon from "@mui/icons-material/Construction";
+import { useNavigate } from "react-router-dom";
+
+const ProspeccaoPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      height="80vh"
+      textAlign="center"
+    >
+      <ConstructionIcon sx={{ fontSize: 80, mb: 2, color: "primary.main" }} />
+      <Typography variant="h3" gutterBottom>
+        Funcionalidade em Desenvolvimento 🚧
+      </Typography>
+      <Typography variant="body1" mb={4}>
+        Estamos trabalhando nesta funcionalidade. Em breve, ela estará disponível para você!
+      </Typography>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={() => navigate("/dashboard")}
+      >
+        Voltar para o Painel
+      </Button>
+    </Box>
+  );
+};
+
+export default ProspeccaoPage;


### PR DESCRIPTION
## Summary
- add new placeholder screens for agent features under development
- wire up `/agent/edital` and `/agent/prospeccao` routes to new pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68487796ffe48333946fded25d2b6365