### PR TITLE
Add Prettier configuration and docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+build
+dist
+dist-ssr

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "auto"
+}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ src/
 └── vite-env.d.ts
 ```
 
+## Padronizacao de Codigo
+
+Para manter a formatacao consistente, utilize o [Prettier](https://prettier.io/) com o arquivo `.prettierrc` presente na raiz do projeto. Instale a extensao **Prettier - Code formatter** no VSCode (ou editor de preferencia) e ative a opcao **Format on Save**.
+
 ## Colaborador
 
 - Efrain Marcelo Pulgar Pantaleon - [efrainmpp1](https://github.com/efrainmpp1)


### PR DESCRIPTION
## Summary
- add `.prettierrc.json` with common formatting rules
- ignore build artifacts via `.prettierignore`
- document how to enable Prettier formatting in README

## Testing
- `npm run lint` *(fails: ESLint not installed)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849b1eeffc08333b1bd3630407c5216