### PR TITLE
Refatora header do dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-router-dom": "^6.22.1",
     "react-scroll": "^1.8.9",
     "axios": "^1.6.5",
-    "firebase": "^10.11.0"
+    "firebase": "^10.11.0",
+    "recharts": "^2.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/screens/Dashboard/DashboardActionButton.tsx
+++ b/src/screens/Dashboard/DashboardActionButton.tsx
@@ -19,25 +19,37 @@ const DashboardActionButton: React.FC<DashboardActionButtonProps> = ({ icon, lab
     animate={{ opacity: 1, y: 0 }}
     transition={{ duration: 0.3 }}
     whileHover={{ scale: 1.05 }}
-    sx={{
+    sx={(theme) => ({
       textDecoration: "none",
       display: "flex",
       flexDirection: "column",
       alignItems: "center",
       justifyContent: "center",
-      bgcolor: "background.paper",
-      color: "text.primary",
+      background: theme.palette.gradients.purplePink,
+      color: theme.palette.common.white,
       borderRadius: 2,
-      boxShadow: 1,
+      boxShadow: theme.customShadows.neon,
       p: 3,
       height: "100%",
       transition: "box-shadow 0.3s ease",
-      "&:hover": {
-        boxShadow: 3,
-      },
-    }}
+      '&:hover': { boxShadow: theme.customShadows.button },
+    })}
   >
-    <Box sx={{ mb: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>{icon}</Box>
+    <Box
+      sx={(theme) => ({
+        mb: 1,
+        p: 1,
+        borderRadius: "50%",
+        background: theme.palette.gradients.bluePurple,
+        boxShadow: theme.customShadows.button,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      })}
+      aria-label={label}
+    >
+      {icon}
+    </Box>
     <Typography variant="subtitle1" align="center">
       {label}
     </Typography>

--- a/src/screens/Dashboard/DashboardAlert.tsx
+++ b/src/screens/Dashboard/DashboardAlert.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Alert, Collapse, IconButton } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+
+interface DashboardAlertProps {
+  severity: "error" | "warning" | "info" | "success";
+  message: string;
+  onClose?: () => void;
+}
+
+const DashboardAlert: React.FC<DashboardAlertProps> = ({
+  severity,
+  message,
+  onClose,
+}) => (
+  <Collapse in>
+    <Alert
+      severity={severity}
+      sx={{ mb: 2 }}
+      action={
+        onClose ? (
+          <IconButton
+            aria-label="Fechar alerta"
+            color="inherit"
+            size="small"
+            onClick={onClose}
+          >
+            <CloseIcon fontSize="inherit" />
+          </IconButton>
+        ) : undefined
+      }
+    >
+      {message}
+    </Alert>
+  </Collapse>
+);
+
+export default DashboardAlert;

--- a/src/screens/Dashboard/DashboardAlert.tsx
+++ b/src/screens/Dashboard/DashboardAlert.tsx
@@ -16,7 +16,8 @@ const DashboardAlert: React.FC<DashboardAlertProps> = ({
   <Collapse in>
     <Alert
       severity={severity}
-      sx={{ mb: 2 }}
+      variant="filled"
+      sx={(theme) => ({ mb: 2, boxShadow: theme.customShadows.neon })}
       action={
         onClose ? (
           <IconButton

--- a/src/screens/Dashboard/DashboardStatCard.tsx
+++ b/src/screens/Dashboard/DashboardStatCard.tsx
@@ -48,25 +48,45 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
-    whileHover={{ scale: 1.03 }}
-    sx={{
-      p: 2,
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "flex-start",
-      bgcolor: "background.paper",
-      borderRadius: 2,
-      boxShadow: 1,
-      transition: "box-shadow 0.3s ease",
-      "&:hover": { boxShadow: 3 },
-    }}
-  >
-    <Box sx={{ mb: 1, display: "flex", alignItems: "center", color: `${statusColor}.main` }}>
-      <Box sx={{ mr: 1 }}>{icon}</Box>
-      <Typography variant="caption" color="text.secondary">
-        {label}
-      </Typography>
-    </Box>
+      whileHover={{ scale: 1.03 }}
+      sx={{
+        p: 2,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+        background: theme.palette.gradients.bluePurple,
+        color: "common.white",
+        borderRadius: 2,
+        boxShadow: theme.customShadows.neon,
+      }}
+    >
+      <Box
+        sx={{
+          mb: 1,
+          display: "flex",
+          alignItems: "center",
+          color: theme.palette[statusColor].light,
+        }}
+      >
+        <Box
+          sx={{
+            mr: 1,
+            p: 0.5,
+            borderRadius: "50%",
+            background: theme.palette.gradients.purplePink,
+            boxShadow: theme.customShadows.button,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+          aria-label={label}
+        >
+          {icon}
+        </Box>
+        <Typography variant="caption" sx={{ color: "grey.100" }}>
+          {label}
+        </Typography>
+      </Box>
     <Typography variant="h6" sx={{ fontWeight: 700 }}>
       {value}
     </Typography>

--- a/src/screens/Dashboard/DashboardStatCard.tsx
+++ b/src/screens/Dashboard/DashboardStatCard.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { Box, Typography, LinearProgress, Button } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import { Link as RouterLink } from "react-router-dom";
 import { motion } from "framer-motion";
+import MiniTrendChart from "./MiniTrendChart";
 
 interface DashboardStatCardProps {
   icon: React.ReactNode;
@@ -19,6 +21,9 @@ interface DashboardStatCardProps {
     | "success";
   actionLabel?: string;
   actionTo?: string;
+  chartData?: { value: number }[];
+  chartColor?: string;
+  chartArea?: boolean;
 }
 
 const MotionBox = motion(Box);
@@ -31,11 +36,18 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
   statusColor = "primary",
   actionLabel,
   actionTo,
-}) => (
-  <MotionBox
-    initial={{ opacity: 0, y: 20 }}
-    animate={{ opacity: 1, y: 0 }}
-    transition={{ duration: 0.3 }}
+  chartData,
+  chartColor,
+  chartArea,
+}) => {
+  const theme = useTheme();
+  const color = chartColor || theme.palette[statusColor].main;
+
+  return (
+    <MotionBox
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
     whileHover={{ scale: 1.03 }}
     sx={{
       p: 2,
@@ -66,6 +78,11 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
         sx={{ mt: 1, width: "100%", height: 6, borderRadius: 3 }}
       />
     )}
+    {chartData && (
+      <Box sx={{ width: "100%", mt: 1 }}>
+        <MiniTrendChart data={chartData} color={color} area={chartArea} ariaLabel={label} />
+      </Box>
+    )}
     {actionLabel && actionTo && (
       <Button
         component={RouterLink}
@@ -78,6 +95,7 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
       </Button>
     )}
   </MotionBox>
-);
+  );
+};
 
 export default DashboardStatCard;

--- a/src/screens/Dashboard/DashboardStatCard.tsx
+++ b/src/screens/Dashboard/DashboardStatCard.tsx
@@ -1,16 +1,37 @@
 import React from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, LinearProgress, Button } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
 import { motion } from "framer-motion";
 
 interface DashboardStatCardProps {
   icon: React.ReactNode;
   label: string;
   value: React.ReactNode;
+  progress?: number;
+  /**
+   * MUI color applied to progress bar and icon
+   */
+  statusColor?:
+    | "primary"
+    | "secondary"
+    | "error"
+    | "warning"
+    | "success";
+  actionLabel?: string;
+  actionTo?: string;
 }
 
 const MotionBox = motion(Box);
 
-const DashboardStatCard: React.FC<DashboardStatCardProps> = ({ icon, label, value }) => (
+const DashboardStatCard: React.FC<DashboardStatCardProps> = ({
+  icon,
+  label,
+  value,
+  progress,
+  statusColor = "primary",
+  actionLabel,
+  actionTo,
+}) => (
   <MotionBox
     initial={{ opacity: 0, y: 20 }}
     animate={{ opacity: 1, y: 0 }}
@@ -19,7 +40,8 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({ icon, label, valu
     sx={{
       p: 2,
       display: "flex",
-      alignItems: "center",
+      flexDirection: "column",
+      alignItems: "flex-start",
       bgcolor: "background.paper",
       borderRadius: 2,
       boxShadow: 1,
@@ -27,15 +49,34 @@ const DashboardStatCard: React.FC<DashboardStatCardProps> = ({ icon, label, valu
       "&:hover": { boxShadow: 3 },
     }}
   >
-    <Box sx={{ mr: 2, color: "text.secondary" }}>{icon}</Box>
-    <Box>
+    <Box sx={{ mb: 1, display: "flex", alignItems: "center", color: `${statusColor}.main` }}>
+      <Box sx={{ mr: 1 }}>{icon}</Box>
       <Typography variant="caption" color="text.secondary">
         {label}
       </Typography>
-      <Typography variant="h6" sx={{ fontWeight: 700 }}>
-        {value}
-      </Typography>
     </Box>
+    <Typography variant="h6" sx={{ fontWeight: 700 }}>
+      {value}
+    </Typography>
+    {typeof progress === "number" && (
+      <LinearProgress
+        variant="determinate"
+        value={progress}
+        color={statusColor}
+        sx={{ mt: 1, width: "100%", height: 6, borderRadius: 3 }}
+      />
+    )}
+    {actionLabel && actionTo && (
+      <Button
+        component={RouterLink}
+        to={actionTo}
+        size="small"
+        sx={{ mt: 1 }}
+        aria-label={actionLabel}
+      >
+        {actionLabel}
+      </Button>
+    )}
   </MotionBox>
 );
 

--- a/src/screens/Dashboard/Home.tsx
+++ b/src/screens/Dashboard/Home.tsx
@@ -3,22 +3,68 @@ import { Box, Grid } from "@mui/material";
 import { Wallet, Clock, Activity, User } from "lucide-react";
 import DashboardStatCard from "./DashboardStatCard";
 import DashboardActionButton from "./DashboardActionButton";
+import { Link as RouterLink } from "react-router-dom";
 
 const DashboardHome: React.FC = () => {
+  const creditsRemaining = 30;
+  const creditsUsedPercent = 70;
+  const executions = 5;
+  const plan = "Free";
+  const lastExecution = {
+    agent: "LeadGen",
+    date: "10/06/2025 14:00",
+    success: true,
+  };
+
+  const creditsColor =
+    creditsUsedPercent >= 80
+      ? "error"
+      : creditsUsedPercent >= 50
+      ? "warning"
+      : "success";
+
   return (
     <Box>
       <Grid container spacing={2} sx={{ mb: 4 }}>
-        <Grid item xs={12} sm={6} md={4}>
-          <DashboardStatCard icon={<Wallet size={20} />} label="Créditos" value="0" />
+        <Grid item xs={12} sm={6} md={3}>
+          <DashboardStatCard
+            icon={<Wallet size={20} />}
+            label="Créditos Restantes"
+            value={creditsRemaining}
+            progress={creditsUsedPercent}
+            statusColor={creditsColor}
+            actionLabel="Adicionar"
+            actionTo="/dashboard/moedas"
+          />
         </Grid>
-        <Grid item xs={12} sm={6} md={4}>
-          <DashboardStatCard icon={<Activity size={20} />} label="Execuções" value="0" />
+        <Grid item xs={12} sm={6} md={3}>
+          <DashboardStatCard
+            icon={<Activity size={20} />}
+            label="Execuções"
+            value={executions}
+            statusColor="primary"
+            actionLabel="Ver histórico"
+            actionTo="/dashboard/historico"
+          />
         </Grid>
-        <Grid item xs={12} sm={6} md={4}>
-          <DashboardStatCard icon={<Clock size={20} />} label="Última Execução" value="-" />
+        <Grid item xs={12} sm={6} md={3}>
+          <DashboardStatCard
+            icon={<Clock size={20} />}
+            label="Última Execução"
+            value={lastExecution.agent ? `${lastExecution.agent}` : "-"}
+            statusColor={lastExecution.success ? "success" : "error"}
+            actionLabel="Detalhes"
+            actionTo="/dashboard/historico"
+          />
         </Grid>
-        <Grid item xs={12} sm={6} md={4}>
-          <DashboardStatCard icon={<User size={20} />} label="Plano" value="Free" />
+        <Grid item xs={12} sm={6} md={3}>
+          <DashboardStatCard
+            icon={<User size={20} />}
+            label="Plano Atual"
+            value={plan}
+            actionLabel="Upgrade"
+            actionTo="/planos"
+          />
         </Grid>
       </Grid>
       <Grid container spacing={2}>

--- a/src/screens/Dashboard/Home.tsx
+++ b/src/screens/Dashboard/Home.tsx
@@ -4,6 +4,7 @@ import { Wallet, Clock, Activity, User } from "lucide-react";
 import DashboardStatCard from "./DashboardStatCard";
 import DashboardActionButton from "./DashboardActionButton";
 import RecentActivityItem from "./RecentActivityItem";
+import NextStepItem from "./NextStepItem";
 import { Link as RouterLink } from "react-router-dom";
 
 const DashboardHome: React.FC = () => {
@@ -60,6 +61,27 @@ const DashboardHome: React.FC = () => {
     { value: 2 },
     { value: 3 },
     { value: 5 },
+  ];
+
+  const nextSteps = [
+    {
+      icon: <Activity size={18} />,
+      text: "Execute um agente agora",
+      actionLabel: "Executar",
+      actionTo: "/dashboard/agente",
+    },
+    {
+      icon: <Wallet size={18} />,
+      text: "Adicione créditos e continue prospectando",
+      actionLabel: "Adicionar",
+      actionTo: "/dashboard/moedas",
+    },
+    {
+      icon: <User size={18} />,
+      text: "Veja dicas para melhorar seus resultados",
+      actionLabel: "Ver dicas",
+      actionTo: "/ajuda",
+    },
   ];
 
   return (
@@ -127,6 +149,14 @@ const DashboardHome: React.FC = () => {
         >
           Ver tudo
         </Button>
+      </Box>
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          Próximos Passos
+        </Typography>
+        {nextSteps.map((step, idx) => (
+          <NextStepItem key={idx} {...step} />
+        ))}
       </Box>
       <Grid container spacing={2}>
         <Grid item xs={6} md={3}>

--- a/src/screens/Dashboard/Home.tsx
+++ b/src/screens/Dashboard/Home.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Box, Grid } from "@mui/material";
+import { Box, Grid, Typography, Button } from "@mui/material";
 import { Wallet, Clock, Activity, User } from "lucide-react";
 import DashboardStatCard from "./DashboardStatCard";
 import DashboardActionButton from "./DashboardActionButton";
+import RecentActivityItem from "./RecentActivityItem";
 import { Link as RouterLink } from "react-router-dom";
 
 const DashboardHome: React.FC = () => {
@@ -15,6 +16,29 @@ const DashboardHome: React.FC = () => {
     date: "10/06/2025 14:00",
     success: true,
   };
+
+  const recentActivities = [
+    {
+      icon: <Activity size={18} />,
+      description: "Executou LeadGen",
+      date: "10/06/2025 14:00",
+      statusColor: "success" as const,
+      actionLabel: "Ver",
+      actionTo: "/dashboard/historico",
+    },
+    {
+      icon: <Wallet size={18} />,
+      description: "Adicionou 20 créditos",
+      date: "08/06/2025 12:30",
+      statusColor: "secondary" as const,
+    },
+    {
+      icon: <User size={18} />,
+      description: "Upgrade para plano Pro",
+      date: "05/06/2025 09:00",
+      statusColor: "primary" as const,
+    },
+  ];
 
   const creditsColor =
     creditsUsedPercent >= 80
@@ -67,6 +91,23 @@ const DashboardHome: React.FC = () => {
           />
         </Grid>
       </Grid>
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          Atividades Recentes
+        </Typography>
+        {recentActivities.map((activity, idx) => (
+          <RecentActivityItem key={idx} {...activity} />
+        ))}
+        <Button
+          component={RouterLink}
+          to="/dashboard/historico"
+          size="small"
+          sx={{ mt: 1 }}
+          aria-label="Ver todas as atividades"
+        >
+          Ver tudo
+        </Button>
+      </Box>
       <Grid container spacing={2}>
         <Grid item xs={6} md={3}>
           <DashboardActionButton

--- a/src/screens/Dashboard/Home.tsx
+++ b/src/screens/Dashboard/Home.tsx
@@ -47,6 +47,21 @@ const DashboardHome: React.FC = () => {
       ? "warning"
       : "success";
 
+  const creditsTrend = [
+    { value: 50 },
+    { value: 40 },
+    { value: 35 },
+    { value: 30 },
+    { value: 30 },
+  ];
+  const executionsTrend = [
+    { value: 1 },
+    { value: 2 },
+    { value: 2 },
+    { value: 3 },
+    { value: 5 },
+  ];
+
   return (
     <Box>
       <Grid container spacing={2} sx={{ mb: 4 }}>
@@ -59,6 +74,9 @@ const DashboardHome: React.FC = () => {
             statusColor={creditsColor}
             actionLabel="Adicionar"
             actionTo="/dashboard/moedas"
+            chartData={creditsTrend}
+            chartColor="#00e676"
+            chartArea
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
@@ -69,6 +87,8 @@ const DashboardHome: React.FC = () => {
             statusColor="primary"
             actionLabel="Ver histórico"
             actionTo="/dashboard/historico"
+            chartData={executionsTrend}
+            chartColor="#ff9100"
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>

--- a/src/screens/Dashboard/Home.tsx
+++ b/src/screens/Dashboard/Home.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { Box, Grid, Typography, Button } from "@mui/material";
 import { Wallet, Clock, Activity, User } from "lucide-react";
 import DashboardStatCard from "./DashboardStatCard";
 import DashboardActionButton from "./DashboardActionButton";
 import RecentActivityItem from "./RecentActivityItem";
 import NextStepItem from "./NextStepItem";
+import DashboardAlert from "./DashboardAlert";
 import { Link as RouterLink } from "react-router-dom";
 
 const DashboardHome: React.FC = () => {
@@ -48,6 +49,36 @@ const DashboardHome: React.FC = () => {
       ? "warning"
       : "success";
 
+  const [alerts, setAlerts] = useState(() => {
+    const items = [] as { id: number; severity: "error" | "success" | "info" | "warning"; message: string; dismissible?: boolean }[];
+    if (creditsRemaining < 10) {
+      items.push({
+        id: 1,
+        severity: "error",
+        message: "Seus créditos estão quase acabando. Adicione mais para continuar.",
+      });
+    }
+    if (executions >= 10) {
+      items.push({
+        id: 2,
+        severity: "success",
+        message: `Parabéns, você executou ${executions} agentes este mês!`,
+        dismissible: true,
+      });
+    }
+    items.push({
+      id: 3,
+      severity: "info",
+      message: "Confira as novidades e recursos que acabamos de lançar.",
+      dismissible: true,
+    });
+    return items;
+  });
+
+  const handleCloseAlert = (id: number) => {
+    setAlerts((prev) => prev.filter((a) => a.id !== id));
+  };
+
   const creditsTrend = [
     { value: 50 },
     { value: 40 },
@@ -86,6 +117,14 @@ const DashboardHome: React.FC = () => {
 
   return (
     <Box>
+      {alerts.map((alert) => (
+        <DashboardAlert
+          key={alert.id}
+          severity={alert.severity}
+          message={alert.message}
+          onClose={alert.dismissible ? () => handleCloseAlert(alert.id) : undefined}
+        />
+      ))}
       <Grid container spacing={2} sx={{ mb: 4 }}>
         <Grid item xs={12} sm={6} md={3}>
           <DashboardStatCard

--- a/src/screens/Dashboard/Home.tsx
+++ b/src/screens/Dashboard/Home.tsx
@@ -172,8 +172,18 @@ const DashboardHome: React.FC = () => {
           />
         </Grid>
       </Grid>
+      <Box sx={{ height: 2, background: (theme) => theme.palette.gradients.purplePink, borderRadius: 1, mb: 4 }} />
       <Box sx={{ mb: 4 }}>
-        <Typography variant="h6" sx={{ mb: 2 }}>
+        <Typography
+          variant="h6"
+          sx={{
+            mb: 2,
+            fontWeight: 700,
+            background: (theme) => theme.palette.gradients.purplePink,
+            WebkitBackgroundClip: "text",
+            WebkitTextFillColor: "transparent",
+          }}
+        >
           Atividades Recentes
         </Typography>
         {recentActivities.map((activity, idx) => (
@@ -189,8 +199,18 @@ const DashboardHome: React.FC = () => {
           Ver tudo
         </Button>
       </Box>
+      <Box sx={{ height: 2, background: (theme) => theme.palette.gradients.purplePink, borderRadius: 1, mb: 4 }} />
       <Box sx={{ mb: 4 }}>
-        <Typography variant="h6" sx={{ mb: 2 }}>
+        <Typography
+          variant="h6"
+          sx={{
+            mb: 2,
+            fontWeight: 700,
+            background: (theme) => theme.palette.gradients.purplePink,
+            WebkitBackgroundClip: "text",
+            WebkitTextFillColor: "transparent",
+          }}
+        >
           Próximos Passos
         </Typography>
         {nextSteps.map((step, idx) => (

--- a/src/screens/Dashboard/MiniTrendChart.tsx
+++ b/src/screens/Dashboard/MiniTrendChart.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { ResponsiveContainer, LineChart, Line, AreaChart, Area } from "recharts";
+
+interface MiniTrendChartProps {
+  /** Data points with numeric value */
+  data: { value: number }[];
+  /** CSS color of the chart line/area */
+  color?: string;
+  /** If true, renders an area chart instead of a line */
+  area?: boolean;
+  /** Accessible label */
+  ariaLabel?: string;
+}
+
+const MiniTrendChart: React.FC<MiniTrendChartProps> = ({
+  data,
+  color = "#8884d8",
+  area = false,
+  ariaLabel,
+}) => (
+  <ResponsiveContainer width="100%" height={50}>
+    {area ? (
+      <AreaChart data={data} aria-label={ariaLabel}>
+        <Area
+          type="monotone"
+          dataKey="value"
+          stroke={color}
+          fill={color}
+          strokeWidth={2}
+          dot={false}
+        />
+      </AreaChart>
+    ) : (
+      <LineChart data={data} aria-label={ariaLabel}>
+        <Line
+          type="monotone"
+          dataKey="value"
+          stroke={color}
+          strokeWidth={2}
+          dot={false}
+        />
+      </LineChart>
+    )}
+  </ResponsiveContainer>
+);
+
+export default MiniTrendChart;

--- a/src/screens/Dashboard/NextStepItem.tsx
+++ b/src/screens/Dashboard/NextStepItem.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Box, Typography, Button } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import { motion } from "framer-motion";
+
+interface NextStepItemProps {
+  icon: React.ReactNode;
+  text: string;
+  actionLabel: string;
+  actionTo: string;
+}
+
+const MotionBox = motion(Box);
+
+const NextStepItem: React.FC<NextStepItemProps> = ({
+  icon,
+  text,
+  actionLabel,
+  actionTo,
+}) => (
+  <MotionBox
+    initial={{ opacity: 0, x: 10 }}
+    animate={{ opacity: 1, x: 0 }}
+    transition={{ duration: 0.3 }}
+    sx={{
+      display: "flex",
+      alignItems: "center",
+      p: 2,
+      mb: 1,
+      bgcolor: "background.paper",
+      borderRadius: 2,
+      boxShadow: 1,
+      transition: "box-shadow 0.3s ease",
+      "&:hover": { boxShadow: 3 },
+    }}
+  >
+    <Box sx={{ mr: 2 }} aria-label="Ícone da sugestão">
+      {icon}
+    </Box>
+    <Box sx={{ flexGrow: 1 }}>
+      <Typography variant="body2">{text}</Typography>
+    </Box>
+    <Button
+      component={RouterLink}
+      to={actionTo}
+      size="small"
+      aria-label={actionLabel}
+    >
+      {actionLabel}
+    </Button>
+  </MotionBox>
+);
+
+export default NextStepItem;

--- a/src/screens/Dashboard/NextStepItem.tsx
+++ b/src/screens/Dashboard/NextStepItem.tsx
@@ -22,19 +22,30 @@ const NextStepItem: React.FC<NextStepItemProps> = ({
     initial={{ opacity: 0, x: 10 }}
     animate={{ opacity: 1, x: 0 }}
     transition={{ duration: 0.3 }}
-    sx={{
+    sx={(theme) => ({
       display: "flex",
       alignItems: "center",
       p: 2,
       mb: 1,
-      bgcolor: "background.paper",
+      background: theme.palette.gradients.bluePurple,
+      color: theme.palette.common.white,
       borderRadius: 2,
-      boxShadow: 1,
-      transition: "box-shadow 0.3s ease",
-      "&:hover": { boxShadow: 3 },
-    }}
+      boxShadow: theme.customShadows.neon,
+    })}
   >
-    <Box sx={{ mr: 2 }} aria-label="Ícone da sugestão">
+    <Box
+      sx={(theme) => ({
+        mr: 2,
+        p: 0.5,
+        borderRadius: "50%",
+        background: theme.palette.gradients.purplePink,
+        boxShadow: theme.customShadows.button,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      })}
+      aria-label="Ícone da sugestão"
+    >
       {icon}
     </Box>
     <Box sx={{ flexGrow: 1 }}>

--- a/src/screens/Dashboard/RecentActivityItem.tsx
+++ b/src/screens/Dashboard/RecentActivityItem.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Box, Typography, Button } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import { motion } from "framer-motion";
+
+interface RecentActivityItemProps {
+  icon: React.ReactNode;
+  description: string;
+  date: string;
+  statusColor?: "primary" | "secondary" | "error" | "warning" | "success";
+  actionLabel?: string;
+  actionTo?: string;
+}
+
+const MotionBox = motion(Box);
+
+const RecentActivityItem: React.FC<RecentActivityItemProps> = ({
+  icon,
+  description,
+  date,
+  statusColor = "primary",
+  actionLabel,
+  actionTo,
+}) => (
+  <MotionBox
+    initial={{ opacity: 0, x: -10 }}
+    animate={{ opacity: 1, x: 0 }}
+    transition={{ duration: 0.3 }}
+    sx={{
+      display: "flex",
+      alignItems: "center",
+      p: 2,
+      mb: 1,
+      bgcolor: "background.paper",
+      borderRadius: 2,
+      boxShadow: 1,
+      transition: "box-shadow 0.3s ease",
+      "&:hover": { boxShadow: 3 },
+    }}
+  >
+    <Box sx={{ mr: 2, color: `${statusColor}.main` }} aria-label="Ícone da atividade">
+      {icon}
+    </Box>
+    <Box sx={{ flexGrow: 1 }}>
+      <Typography variant="body2">{description}</Typography>
+      <Typography variant="caption" color="text.secondary">
+        {date}
+      </Typography>
+    </Box>
+    {actionLabel && actionTo && (
+      <Button
+        component={RouterLink}
+        to={actionTo}
+        size="small"
+        aria-label={actionLabel}
+      >
+        {actionLabel}
+      </Button>
+    )}
+  </MotionBox>
+);
+
+export default RecentActivityItem;

--- a/src/screens/Dashboard/RecentActivityItem.tsx
+++ b/src/screens/Dashboard/RecentActivityItem.tsx
@@ -26,19 +26,31 @@ const RecentActivityItem: React.FC<RecentActivityItemProps> = ({
     initial={{ opacity: 0, x: -10 }}
     animate={{ opacity: 1, x: 0 }}
     transition={{ duration: 0.3 }}
-    sx={{
+    sx={(theme) => ({
       display: "flex",
       alignItems: "center",
       p: 2,
       mb: 1,
-      bgcolor: "background.paper",
+      background: theme.palette.gradients.bluePurple,
+      color: theme.palette.common.white,
       borderRadius: 2,
-      boxShadow: 1,
-      transition: "box-shadow 0.3s ease",
-      "&:hover": { boxShadow: 3 },
-    }}
+      boxShadow: theme.customShadows.neon,
+    })}
   >
-    <Box sx={{ mr: 2, color: `${statusColor}.main` }} aria-label="Ícone da atividade">
+    <Box
+      sx={(theme) => ({
+        mr: 2,
+        p: 0.5,
+        borderRadius: "50%",
+        background: theme.palette.gradients.purplePink,
+        boxShadow: theme.customShadows.button,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        color: theme.palette[statusColor].main,
+      })}
+      aria-label="Ícone da atividade"
+    >
       {icon}
     </Box>
     <Box sx={{ flexGrow: 1 }}>

--- a/src/screens/Dashboard/index.tsx
+++ b/src/screens/Dashboard/index.tsx
@@ -13,6 +13,10 @@ import {
   useMediaQuery,
   useTheme,
   Avatar,
+  Tooltip,
+  Badge,
+  Button,
+  LinearProgress,
   Menu as MuiMenu,
   MenuItem,
 } from "@mui/material";
@@ -44,6 +48,15 @@ const DashboardLayout: React.FC = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const [open, setOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const plan = "Free";
+  const progress = 30;
+  const getGreeting = () => {
+    const hour = new Date().getHours();
+    if (hour < 12) return "Bom dia";
+    if (hour < 18) return "Boa tarde";
+    return "Boa noite";
+  };
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -94,7 +107,7 @@ const DashboardLayout: React.FC = () => {
           borderRadius: 1,
         }}
       >
-        <Toolbar sx={{ display: "flex", justifyContent: "space-between" }}>
+        <Toolbar sx={{ display: "flex", justifyContent: "space-between", flexWrap: "wrap", gap: 2 }}>
           <Box sx={{ display: "flex", alignItems: "center" }}>
             {isMobile && (
               <IconButton
@@ -116,28 +129,53 @@ const DashboardLayout: React.FC = () => {
               </Typography>
             </Box>
           </Box>
-          <Box sx={{ display: "flex", alignItems: "center" }}>
-            <Typography variant="subtitle1" sx={{ mr: 1 }} noWrap>
-              {user?.displayName || user?.email}
-            </Typography>
-            <IconButton onClick={handleMenuOpen} color="inherit">
-              {user?.photoURL ? (
-                <Avatar
-                  src={user.photoURL}
-                  alt={user.displayName || user.email || "Usuário"}
-                />
-              ) : (
-                <Avatar>
-                  {(user?.displayName || user?.email || "").charAt(0).toUpperCase()}
-                </Avatar>
-              )}
-            </IconButton>
+          <Box sx={{ display: "flex", alignItems: "center", flexWrap: "wrap", justifyContent: "flex-end", gap: 2 }}>
+            <Box sx={{ textAlign: { xs: "center", md: "right" }, mr: 1 }}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 700,
+                  background: theme.palette.gradients.purplePink,
+                  WebkitBackgroundClip: "text",
+                  WebkitTextFillColor: "transparent",
+                }}
+              >
+                {`${getGreeting()}, ${(user?.displayName || user?.email || "").split(" ")[0]}! Pronto para gerar novos leads hoje?`}
+              </Typography>
+              <LinearProgress
+                variant="determinate"
+                value={progress}
+                sx={{ height: 6, borderRadius: 3, mt: 0.5, bgcolor: "grey.800" }}
+              />
+            </Box>
+            <Tooltip title={`Plano ${plan}`}> 
+              <IconButton onClick={handleMenuOpen} color="inherit" aria-label="Perfil do usuário">
+                <Badge
+                  overlap="circular"
+                  badgeContent={plan}
+                  color="secondary"
+                  anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+                  sx={{
+                    "& .MuiBadge-badge": { fontSize: "0.6rem", height: 16, minWidth: 16 }
+                  }}
+                >
+                  {user?.photoURL ? (
+                    <Avatar src={user.photoURL} alt={user.displayName || user.email || "Usuário"} />
+                  ) : (
+                    <Avatar>{(user?.displayName || user?.email || "").charAt(0).toUpperCase()}</Avatar>
+                  )}
+                </Badge>
+              </IconButton>
+            </Tooltip>
             <MuiMenu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
               <MenuItem component={RouterLink} to="/dashboard/perfil" onClick={handleMenuClose}>
                 Ver Perfil
               </MenuItem>
               <MenuItem onClick={handleLogout}>Sair</MenuItem>
             </MuiMenu>
+            <Button variant="contained" color="secondary" sx={{ ml: 1 }} aria-label="Adicionar créditos">
+              Adicionar Créditos
+            </Button>
           </Box>
         </Toolbar>
       </AppBar>

--- a/src/screens/Dashboard/index.tsx
+++ b/src/screens/Dashboard/index.tsx
@@ -173,7 +173,16 @@ const DashboardLayout: React.FC = () => {
               </MenuItem>
               <MenuItem onClick={handleLogout}>Sair</MenuItem>
             </MuiMenu>
-            <Button variant="contained" color="secondary" sx={{ ml: 1 }} aria-label="Adicionar créditos">
+            <Button
+              variant="contained"
+              aria-label="Adicionar créditos"
+              sx={(theme) => ({
+                ml: 1,
+                background: theme.palette.gradients.purplePink,
+                boxShadow: theme.customShadows.neon,
+                '&:hover': { background: theme.palette.gradients.bluePurple },
+              })}
+            >
               Adicionar Créditos
             </Button>
           </Box>


### PR DESCRIPTION
## Summary
- add greeting, progress and plan info in dashboard header
- show avatar badge and CTA button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68508ee9d8cc8333bd68f30e1f1a69a5