### PR TITLE
Add API URL env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+VITE_FIREBASE_API_KEY=your_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your_auth_domain
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+VITE_FIREBASE_APP_ID=your_app_id
+VITE_API_NODE_URL=http://localhost:3331
+VITE_API_IA_URL=http://localhost:3333

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ VITE_FIREBASE_PROJECT_ID=your_project_id
 VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
 VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
+VITE_API_NODE_URL=http://localhost:3331
+VITE_API_IA_URL=http://localhost:3333
 ```
 
 ## Tecnologias Utilizadas

--- a/src/services/apiIA.ts
+++ b/src/services/apiIA.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
 export const apiIA = axios.create({
-  baseURL: 'http://localhost:3333',
+  baseURL: import.meta.env.VITE_API_IA_URL,
   timeout: 20000,
 });

--- a/src/services/apiNode.ts
+++ b/src/services/apiNode.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
 export const apiNode = axios.create({
-  baseURL: 'http://localhost:3331',
+  baseURL: import.meta.env.VITE_API_NODE_URL,
   timeout: 10000,
 });


### PR DESCRIPTION
## Summary
- add default `.env` with Firebase and API URLs
- load API base URLs from `import.meta.env`
- document API URL env vars

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851865af2d48333b13a35f6977d383f