### PR TITLE
Add domain layer for services and credits

### DIFF
--- a/src/screens/Dashboard/Coins.tsx
+++ b/src/screens/Dashboard/Coins.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Card, Typography, Button, Box } from "@mui/material";
 import { useNavigate } from "react-router-dom";
-import { apiNode } from "../../services/apiNode";
+import { getBalance, buyCredits } from "../../services/credits";
 
 const CoinsPage: React.FC = () => {
   const [balance, setBalance] = useState(0);
@@ -10,10 +10,8 @@ const CoinsPage: React.FC = () => {
   useEffect(() => {
     const fetchBalance = async () => {
       try {
-        const { data } = await apiNode.get("/credits");
-        if (typeof data.balance === "number") {
-          setBalance(data.balance);
-        }
+        const value = await getBalance();
+        setBalance(value);
       } catch (err) {
         console.error("Erro ao buscar saldo de moedas", err);
       }
@@ -24,7 +22,7 @@ const CoinsPage: React.FC = () => {
 
   const handleBuyCredits = async () => {
     try {
-      await apiNode.post("/credits/buy");
+      await buyCredits();
       navigate("/comprar-moedas");
     } catch (err) {
       console.error("Erro ao comprar moedas", err);

--- a/src/screens/FeatureDetail/index.tsx
+++ b/src/screens/FeatureDetail/index.tsx
@@ -11,7 +11,8 @@ import BuscaBenefitsSection from '../../components/BuscaDescritiva/BuscaBenefits
 import BuscaAudienceSection from '../../components/BuscaDescritiva/BuscaAudienceSection';
 import BuscaFinalCTASection from '../../components/BuscaDescritiva/BuscaFinalCTASection';
 import BackHomeButton from '../../libs/components/BackHomeButton';
-import { getServiceById } from '../../services/Services';
+import { getServiceById } from '../../services/services';
+import { Service } from '../../libs/interfaces/Service';
 
 interface FeatureDetailPageProps {
   serviceId?: string;
@@ -20,8 +21,15 @@ interface FeatureDetailPageProps {
 const FeatureDetailPage: React.FC<FeatureDetailPageProps> = ({ serviceId }) => {
   const params = useParams<{ id: string }>();
   const id = serviceId ?? params.id;
+  const [service, setService] = React.useState<Service | undefined>();
 
-  const service = getServiceById(id ?? '');
+  React.useEffect(() => {
+    const load = async () => {
+      const result = await getServiceById(id ?? '');
+      setService(result);
+    };
+    load();
+  }, [id]);
 
   if (!service) {
     return (

--- a/src/screens/Service/index.tsx
+++ b/src/screens/Service/index.tsx
@@ -10,12 +10,20 @@ import {
   Grid,
 } from "@mui/material";
 import BackHomeButton from "../../libs/components/BackHomeButton";
-import { getServiceById } from "../../services/Services";
+import { getServiceById } from "../../services/services";
+import { Service } from "../../libs/interfaces/Service";
 
 const ServicePage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const [service, setService] = React.useState<Service | undefined>();
 
-  const service = getServiceById(id ?? "");
+  React.useEffect(() => {
+    const load = async () => {
+      const result = await getServiceById(id ?? "");
+      setService(result);
+    };
+    load();
+  }, [id]);
 
   if (!service) {
     return (

--- a/src/services/credits/index.ts
+++ b/src/services/credits/index.ts
@@ -1,0 +1,3 @@
+const useMock = !import.meta.env.PROD;
+
+export * from (useMock ? './mock' : './integration');

--- a/src/services/credits/integration.ts
+++ b/src/services/credits/integration.ts
@@ -1,0 +1,10 @@
+import { apiNode } from '../apiNode';
+
+export const getBalance = async (): Promise<number> => {
+  const { data } = await apiNode.get<{ balance: number }>('/credits');
+  return data.balance;
+};
+
+export const buyCredits = async (): Promise<void> => {
+  await apiNode.post('/credits/buy');
+};

--- a/src/services/credits/mock.ts
+++ b/src/services/credits/mock.ts
@@ -1,0 +1,9 @@
+let balance = 0;
+
+export const getBalance = async (): Promise<number> => {
+  return balance;
+};
+
+export const buyCredits = async (): Promise<void> => {
+  balance += 10;
+};

--- a/src/services/services/index.js
+++ b/src/services/services/index.js
@@ -1,0 +1,8 @@
+const useMock = process.env.NODE_ENV !== 'production';
+let mod;
+if (useMock) {
+  mod = await import('./mock.js');
+} else {
+  mod = await import('./integration.js');
+}
+export const { getServices, getServiceById } = mod;

--- a/src/services/services/index.ts
+++ b/src/services/services/index.ts
@@ -1,0 +1,3 @@
+const useMock = !import.meta.env.PROD;
+
+export * from (useMock ? './mock' : './integration');

--- a/src/services/services/integration.js
+++ b/src/services/services/integration.js
@@ -1,0 +1,11 @@
+import { apiNode } from '../apiNode.js';
+
+export const getServices = async () => {
+  const { data } = await apiNode.get('/services');
+  return data;
+};
+
+export const getServiceById = async (id) => {
+  const { data } = await apiNode.get(`/services/${id}`);
+  return data;
+};

--- a/src/services/services/integration.ts
+++ b/src/services/services/integration.ts
@@ -1,0 +1,12 @@
+import { apiNode } from '../apiNode';
+import { Service } from '../../libs/interfaces/Service';
+
+export const getServices = async (): Promise<Service[]> => {
+  const { data } = await apiNode.get<Service[]>('/services');
+  return data;
+};
+
+export const getServiceById = async (id: string): Promise<Service> => {
+  const { data } = await apiNode.get<Service>(`/services/${id}`);
+  return data;
+};

--- a/src/services/services/mock.js
+++ b/src/services/services/mock.js
@@ -1,0 +1,9 @@
+import { services } from '../mocks/services.js';
+
+export const getServices = async () => {
+  return services;
+};
+
+export const getServiceById = async (id) => {
+  return services.find(service => service.id === id);
+};

--- a/src/services/services/mock.ts
+++ b/src/services/services/mock.ts
@@ -1,0 +1,10 @@
+import { services } from '../mocks/services';
+import { Service } from '../../libs/interfaces/Service';
+
+export const getServices = async (): Promise<Service[]> => {
+  return services;
+};
+
+export const getServiceById = async (id: string): Promise<Service | undefined> => {
+  return services.find(service => service.id === id);
+};

--- a/tests/getServiceById.test.js
+++ b/tests/getServiceById.test.js
@@ -1,14 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { getServiceById } from '../src/services/Services/index.js';
+import { getServiceById } from '../src/services/services/index.js';
 import { services } from '../src/services/mocks/services.js';
 
-test('returns the correct service when provided a known id', () => {
+test('returns the correct service when provided a known id', async () => {
   const id = 'ai-public-bidding';
   const expected = services.find(service => service.id === id);
-  assert.deepEqual(getServiceById(id), expected);
+  assert.deepEqual(await getServiceById(id), expected);
 });
 
-test('returns undefined for an unknown id', () => {
-  assert.equal(getServiceById('unknown-id'), undefined);
+test('returns undefined for an unknown id', async () => {
+  assert.equal(await getServiceById('unknown-id'), undefined);
 });


### PR DESCRIPTION
## Summary
- add credits service domain with mock and integration
- add services service domain with mock and integration
- switch CoinsPage to use credits service
- update Service and FeatureDetail pages to load services asynchronously
- adjust tests for new async service layer

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851867da9508333b0f929c162af929b