### PR TITLE
Fix missing services index file

### DIFF
--- a/src/services/apiNode.js
+++ b/src/services/apiNode.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+export const apiNode = axios.create({
+  baseURL: process.env.VITE_API_NODE_URL,
+  timeout: 10000,
+});

--- a/src/services/services/index.js
+++ b/src/services/services/index.js
@@ -1,0 +1,1 @@
+export * from './mock.js';

--- a/src/services/services/index.ts
+++ b/src/services/services/index.ts
@@ -1,0 +1,11 @@
+import * as mock from './mock';
+import * as integration from './integration';
+import { isProductionEnv } from '../../utils/env';
+
+export const getServices = isProductionEnv()
+  ? integration.getServices
+  : mock.getServices;
+
+export const getServiceById = isProductionEnv()
+  ? integration.getServiceById
+  : mock.getServiceById;


### PR DESCRIPTION
## Summary
- add index module for service API with env selection
- export mock API in JS build for tests
- add JS version of apiNode helper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68519972b01c8333a23f49e66971a139