### PR TITLE
Implement edital analysis status machine

### DIFF
--- a/src/libs/hooks/useAnaliseDeEdital.ts
+++ b/src/libs/hooks/useAnaliseDeEdital.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+import { analyzeEdital } from '../../services/edital';
+
+export type StatusAnalise = 'idle' | 'processando' | 'concluido' | 'erro';
+
+export function useAnaliseDeEdital() {
+  const [statusAnalise, setStatusAnalise] = useState<StatusAnalise>('idle');
+  const [csvBlobUrl, setCsvBlobUrl] = useState<string | null>(null);
+  const [mensagemErro, setMensagemErro] = useState<string | null>(null);
+
+  const analisar = async (arquivoPdf: File) => {
+    setStatusAnalise('processando');
+    setMensagemErro(null);
+    try {
+      const blob = await analyzeEdital(arquivoPdf);
+      const url = URL.createObjectURL(blob);
+      setCsvBlobUrl(url);
+      setStatusAnalise('concluido');
+    } catch (error) {
+      setStatusAnalise('erro');
+      setMensagemErro(
+        'Ocorreu um erro ao analisar o edital. Tente novamente mais tarde.',
+      );
+    }
+  };
+
+  const reset = () => {
+    if (csvBlobUrl) {
+      URL.revokeObjectURL(csvBlobUrl);
+    }
+    setCsvBlobUrl(null);
+    setMensagemErro(null);
+    setStatusAnalise('idle');
+  };
+
+  useEffect(() => {
+    return () => {
+      if (csvBlobUrl) {
+        URL.revokeObjectURL(csvBlobUrl);
+      }
+    };
+  }, [csvBlobUrl]);
+
+  return { statusAnalise, csvBlobUrl, mensagemErro, analisar, reset };
+}


### PR DESCRIPTION
## Summary
- create `useAnaliseDeEdital` hook to manage analysis states
- update `DropzoneUploadPdf` to use the new hook and show progress/download/error

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68542d7999708333bc4edaf158d96cd4