### PR TITLE
Add Prospecção Inteligente route inside dashboard

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -13,6 +13,7 @@ import LoginPage from './screens/Login';
 import RegisterPage from './screens/Register';
 import EditalPage from './screens/Agent/Edital';
 import ProspeccaoPage from './screens/Agent/Prospeccao';
+import ProspeccaoInteligentePage from './screens/ProspeccaoInteligente/ProspeccaoInteligente';
 import DashboardLayout from './screens/Dashboard';
 import DashboardHome from './screens/Dashboard/Home';
 import AgentPage from './screens/Dashboard/Agent';
@@ -81,6 +82,10 @@ const router = createBrowserRouter([
           {
             path: 'analise-edital',
             element: <EditalPage />,
+          },
+          {
+            path: 'prospeccao-inteligente',
+            element: <ProspeccaoInteligentePage />,
           },
           {
             path: 'historico',

--- a/src/screens/Dashboard/Agent.tsx
+++ b/src/screens/Dashboard/Agent.tsx
@@ -26,7 +26,7 @@ const AgentPage: React.FC = () => {
       description:
         "Descreva o tipo de empresa que procura e a IA retorna opções relevantes.",
       icon: <Search size={36} />,
-      path: "/agent/prospeccao",
+      path: "/dashboard/prospeccao-inteligente",
     },
   ];
 

--- a/src/screens/Dashboard/index.tsx
+++ b/src/screens/Dashboard/index.tsx
@@ -27,6 +27,7 @@ import {
   History,
   Coins,
   User,
+  Search,
   BrainCircuit,
 } from "lucide-react";
 import { Outlet, Link as RouterLink } from "react-router-dom";
@@ -37,6 +38,7 @@ const drawerWidth = 240;
 const menuItems = [
   { label: "Dashboard", to: "/dashboard", icon: <LayoutDashboard size={20} /> },
   { label: "Executar Agente", to: "/dashboard/agente", icon: <PlayCircle size={20} /> },
+  { label: "Prospecção Inteligente", to: "/dashboard/prospeccao-inteligente", icon: <Search size={20} /> },
   { label: "Histórico", to: "/dashboard/historico", icon: <History size={20} /> },
   { label: "Minhas Moedas", to: "/dashboard/moedas", icon: <Coins size={20} /> },
   { label: "Perfil", to: "/dashboard/perfil", icon: <User size={20} /> },

--- a/src/screens/ProspeccaoInteligente/ProspeccaoInteligente.tsx
+++ b/src/screens/ProspeccaoInteligente/ProspeccaoInteligente.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import ConstructionIcon from "@mui/icons-material/Construction";
+import BackDashboardButton from "../../libs/components/BackDashboardButton";
+
+const ProspeccaoInteligentePage: React.FC = () => {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      height="80vh"
+      textAlign="center"
+    >
+      <ConstructionIcon sx={{ fontSize: 80, mb: 2, color: "primary.main" }} />
+      <Typography variant="h3" gutterBottom>
+        Funcionalidade em Desenvolvimento 🚧
+      </Typography>
+      <Typography variant="body1" mb={4}>
+        Estamos trabalhando nesta funcionalidade. Em breve, ela estará disponível para você!
+      </Typography>
+      <BackDashboardButton />
+    </Box>
+  );
+};
+
+export default ProspeccaoInteligentePage;


### PR DESCRIPTION
## Summary
- create ProspeccaoInteligente page
- add new dashboard menu item
- update dashboard agent option
- wire /dashboard/prospeccao-inteligente route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854390d7d74833390dbdff87517e793