### PR TITLE
Add dynamic credit usage on Dashboard Home

### DIFF
--- a/src/libs/interfaces/Service.ts
+++ b/src/libs/interfaces/Service.ts
@@ -14,3 +14,8 @@ export interface ServiceBackend {
   description: string;
   price: number;
 }
+
+export interface ServiceBackendSimplify {
+  id: number;
+  name: string;
+}

--- a/src/screens/Dashboard/Home.tsx
+++ b/src/screens/Dashboard/Home.tsx
@@ -10,15 +10,18 @@ import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '../../libs/context/AuthContext';
 import { getNumberOfHistoricalServicesByUserId, getUserByFirebaseUid } from '../../services/users';
 import type { User as AppUser } from '../../libs/interfaces/User';
+import { calculateCreditUsage } from '../../utils/creditUtils';
 
 const DashboardHome: React.FC = () => {
   const { user } = useAuth();
   const [userData, setUserData] = useState<AppUser | null>(null);
   const [numberOfExecutions, setNumberOfExecutions] = useState<number>(0);
 
-  const creditsRemaining = userData?.coins ?? 0;
+  const MAX_CREDITS = 10;
+  const creditsRemaining = userData?.coins ?? MAX_CREDITS;
   const plan = userData?.plan ?? 'Free';
-  const creditsUsedPercent = 70;
+  const creditsUsed = MAX_CREDITS - creditsRemaining;
+  const creditsUsedPercent = calculateCreditUsage(creditsRemaining, MAX_CREDITS);
   const lastExecution = {
     agent: 'LeadGen',
     date: '10/06/2025 14:00',
@@ -152,7 +155,14 @@ const DashboardHome: React.FC = () => {
           <DashboardStatCard
             icon={<Wallet size={20} />}
             label="Créditos Restantes"
-            value={creditsRemaining}
+            value={
+              <Box component="span">
+                {creditsRemaining}
+                <Typography component="span" variant="caption" sx={{ ml: 1 }}>
+                  Usados: {creditsUsed}
+                </Typography>
+              </Box>
+            }
             progress={creditsUsedPercent}
             statusColor={creditsColor}
             actionLabel="Adicionar"

--- a/src/screens/Dashboard/Home.tsx
+++ b/src/screens/Dashboard/Home.tsx
@@ -116,9 +116,6 @@ const DashboardHome: React.FC = () => {
     setAlerts((prev) => prev.filter((a) => a.id !== id));
   };
 
-  const creditsTrend = [{ value: 50 }, { value: 40 }, { value: 35 }, { value: 30 }, { value: 30 }];
-  const executionsTrend = [{ value: 1 }, { value: 2 }, { value: 2 }, { value: 3 }, { value: 5 }];
-
   const nextSteps = [
     {
       icon: <Activity size={18} />,
@@ -165,15 +162,15 @@ const DashboardHome: React.FC = () => {
             }
             progress={creditsUsedPercent}
             statusColor={creditsColor}
-            actionLabel="Adicionar"
-            actionTo="/dashboard/moedas"
-            chartData={creditsTrend}
+            //actionLabel="Adicionar"
+            //actionTo="/dashboard/moedas"
+            //chartData={creditsTrend}
             chartColor="#00e676"
             chartArea
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
-          <DashboardStatCard
+          {/*<DashboardStatCard
             icon={<Activity size={20} />}
             label="Execuções"
             value={numberOfExecutions}
@@ -182,7 +179,7 @@ const DashboardHome: React.FC = () => {
             actionTo="/dashboard/historico"
             chartData={executionsTrend}
             chartColor="#ff9100"
-          />
+          />*/}
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
           <DashboardStatCard
@@ -190,8 +187,8 @@ const DashboardHome: React.FC = () => {
             label="Última Execução"
             value={lastExecution.agent ? `${lastExecution.agent}` : '-'}
             statusColor={lastExecution.success ? 'success' : 'error'}
-            actionLabel="Detalhes"
-            actionTo="/dashboard/historico"
+            //actionLabel="Detalhes"
+            //actionTo="/dashboard/historico"
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
@@ -199,8 +196,8 @@ const DashboardHome: React.FC = () => {
             icon={<User size={20} />}
             label="Plano Atual"
             value={plan}
-            actionLabel="Upgrade"
-            actionTo="/planos"
+            //actionLabel="Upgrade"
+            //actionTo="/planos"
           />
         </Grid>
       </Grid>

--- a/src/screens/Dashboard/Home.tsx
+++ b/src/screens/Dashboard/Home.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Grid, Typography, Button } from '@mui/material';
+import { Box, Grid, Typography /*Button*/ } from '@mui/material';
 import { Wallet, Clock, Activity, User } from 'lucide-react';
 import DashboardStatCard from './DashboardStatCard';
 import DashboardActionButton from './DashboardActionButton';
-import RecentActivityItem from './RecentActivityItem';
+//import RecentActivityItem from './RecentActivityItem';
 import NextStepItem from './NextStepItem';
 import DashboardAlert from './DashboardAlert';
-import { Link as RouterLink } from 'react-router-dom';
+//import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '../../libs/context/AuthContext';
 import {
   getLastServiceUsedByUserId,
@@ -41,7 +41,7 @@ const DashboardHome: React.FC = () => {
     };
     fetchLastServiceUsed();
   }, [userData]);
-
+  /*
   const recentActivities = [
     {
       icon: <Activity size={18} />,
@@ -63,7 +63,7 @@ const DashboardHome: React.FC = () => {
       date: '05/06/2025 09:00',
       statusColor: 'primary' as const,
     },
-  ];
+  ];*/
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -229,6 +229,7 @@ const DashboardHome: React.FC = () => {
           mb: 4,
         }}
       />
+      {/*
       <Box sx={{ mb: 4 }}>
         <Typography
           variant="h6"
@@ -262,7 +263,7 @@ const DashboardHome: React.FC = () => {
           borderRadius: 1,
           mb: 4,
         }}
-      />
+      />*/}
       <Box sx={{ mb: 4 }}>
         <Typography
           variant="h6"

--- a/src/services/users/index.ts
+++ b/src/services/users/index.ts
@@ -12,3 +12,6 @@ export const getUserHistoricalServices = isMockMode()
 export const getNumberOfHistoricalServicesByUserId = isMockMode()
   ? mock.getNumberOfHistoricalServicesByUserId
   : integration.getNumberOfHistoricalServicesByUserId;
+export const getLastServiceUsedByUserId = isMockMode()
+  ? mock.getLastServiceUsedByUserId
+  : integration.getLastServiceUsedByUserId;

--- a/src/services/users/integration.ts
+++ b/src/services/users/integration.ts
@@ -1,6 +1,7 @@
 import { apiNode } from '../apiNode';
 import { RegisterNewUser, User } from '../../libs/interfaces/User';
 import { UserHistoricalService } from '../../libs/interfaces/UserHistoricalService';
+import { ServiceBackendSimplify } from '../../libs/interfaces/Service';
 
 export const registerUser = async (newUserRegisterData: RegisterNewUser): Promise<User> => {
   const { data } = await apiNode.post<{ user: User }>('/users', newUserRegisterData);
@@ -22,4 +23,13 @@ export const getUserHistoricalServices = async (id: number): Promise<UserHistori
 export const getNumberOfHistoricalServicesByUserId = async (id: number): Promise<number> => {
   const { data } = await apiNode.get<{ count: number }>(`/users/${id}/historical-services/count`);
   return data.count;
+};
+
+export const getLastServiceUsedByUserId = async (
+  id: number,
+): Promise<ServiceBackendSimplify | null> => {
+  const { data } = await apiNode.get<{ lastServiceUsed: ServiceBackendSimplify | null }>(
+    `/users/${id}/historical-services/last`,
+  );
+  return data.lastServiceUsed;
 };

--- a/src/services/users/mock.ts
+++ b/src/services/users/mock.ts
@@ -52,3 +52,14 @@ export const getUserHistoricalServices = async (): Promise<UserHistoricalService
     },
   ];
 };
+
+export const getLastServiceUsedByUserId = async (): Promise<{
+  id: number;
+  name: string;
+} | null> => {
+  // Simula a busca do último serviço usado pelo usuário
+  return {
+    id: 3,
+    name: 'Agente de Edital - Licitação',
+  };
+};

--- a/src/utils/creditUtils.ts
+++ b/src/utils/creditUtils.ts
@@ -1,0 +1,4 @@
+export function calculateCreditUsage(currentCredits: number, maxCredits = 10): number {
+  const usedCredits = maxCredits - currentCredits;
+  return (usedCredits / maxCredits) * 100;
+}


### PR DESCRIPTION
## Summary
- add `calculateCreditUsage` util
- show coins, used credits and progress dynamically on Dashboard Home

## Testing
- `npm run lint` *(fails: ESLint not installed)*
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6dd9e53883339e0d838c02cda3ff